### PR TITLE
Fix file path is URI encoded

### DIFF
--- a/denops/@ddu-sources/nvim_lsp.ts
+++ b/denops/@ddu-sources/nvim_lsp.ts
@@ -16,7 +16,7 @@ import {
   WorkspaceSymbol,
 } from "npm:vscode-languageserver-types@3.17.4-next.0";
 import { isLike } from "https://deno.land/x/unknownutil@v2.1.1/is.ts";
-import { isAbsolute, toFileUrl } from "https://deno.land/std@0.190.0/path/mod.ts";
+import { fromFileUrl, isAbsolute, toFileUrl } from "https://deno.land/std@0.190.0/path/mod.ts";
 
 const VALID_METHODS = {
   "textDocument/declaration": "textDocument/declaration",
@@ -327,8 +327,8 @@ function locationToItem(
 }
 
 function uriToPath(uri: string) {
-  if (uri.startsWith("file:")) {
-    return new URL(uri).pathname;
+  if (uri.startsWith("file://")) {
+    return fromFileUrl(uri);
   } else {
     return uri;
   }


### PR DESCRIPTION
File paths were URI encoded and have been fixed.

## Before

<img width="1160" alt="image" src="https://github.com/uga-rosa/ddu-source-nvim_lsp/assets/44780846/a5cebcf3-52e5-45f7-8f1f-c085c071379f">

## After

<img width="1174" alt="image" src="https://github.com/uga-rosa/ddu-source-nvim_lsp/assets/44780846/be0404da-d2ae-4c8b-812a-d0df03056017">
