### PR TITLE
Fix: preview fails cause `codeAction/resolve` returns null

### DIFF
--- a/denops/@ddu-kinds/lsp_codeAction.ts
+++ b/denops/@ddu-kinds/lsp_codeAction.ts
@@ -66,8 +66,8 @@ async function ensureAction(
         "codeAction/resolve",
         item.data,
         action.context.bufNr,
-      ) as CodeAction;
-      action.edit = resolvedCodeAction.edit;
+      ) as CodeAction | undefined;
+      action.edit = resolvedCodeAction?.edit;
     } finally {
       action.resolved = true;
     }

--- a/denops/@ddu-kinds/lsp_codeAction.ts
+++ b/denops/@ddu-kinds/lsp_codeAction.ts
@@ -66,7 +66,7 @@ async function ensureAction(
         "codeAction/resolve",
         item.data,
         action.context.bufNr,
-      ) as CodeAction | undefined;
+      ) as CodeAction | null;
       action.edit = resolvedCodeAction?.edit;
     } finally {
       action.resolved = true;


### PR DESCRIPTION
This fixes a issue of codeAction kind preview feature.

On invoking preview window with codeAction item like `in the workspace`, a error will be caused at `ensureAction` funcion.

```
function <lambda>1109[1]..<SNR>59_do_auto_action[9]..ddu#ui#sync_action[1]..ddu#ui_sync_action[4]..ddu#_request[15]..denops#request[1]..denops#server#request[4]..denops#_internal#server#chan#request[4]..denops#_internal#rpc#nvim#request の処理中にエラーが検出されました:
行    1:
Error invoking 'invoke' on channel 4:
TypeError: Cannot read properties of null (reading 'edit')
    at ensureAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-kinds/lsp_codeAction.ts:70:40)
    at eventLoopTick (ext:core/01_core.js:183:11)
    at async Kind.getPreviewer (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-kinds/lsp_codeAction.ts:118:20)
    at async PreviewUi.previewContents (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-ui-ff/preview.ts:96:23)
    at async Ddu.uiAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/ddu/ddu.ts:727:13)
    at async Object.uiAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/ddu/app.ts#1312.309749:326:9)
    at async dispatch (https://deno.land/x/messagepack_rpc@v2.0.0/dispatcher.ts:36:12)
    at async Session.#dispatch (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:244:22)
    at async Session.#handleRequestMessage (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:271:33)
CursorMoved Autocommands for "<buffer=2>" の処理中にエラーが検出されました:
Error executing lua callback: CursorMoved Autocommands for "<buffer=2>"..function ddu#ui#do_action[1]..ddu#ui#sync_action[1]..ddu#ui_sync_action[4]..ddu#_request[15]..denops#request[1]..denops#server#request[4]..denops#_internal#server#chan#request[4]..denops#_internal#rpc#nvim#request, line 1: Vim(return):Error invoking 'invoke' on channel 4:
TypeError: Cannot read properties of null (reading 'edit')
    at ensureAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-kinds/lsp_codeAction.ts:70:40)
    at eventLoopTick (ext:core/01_core.js:183:11)
    at async Kind.getPreviewer (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-kinds/lsp_codeAction.ts:118:20)
    at async PreviewUi.previewContents (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-ui-ff/preview.ts:96:23)
    at async Ddu.uiAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/ddu/ddu.ts:727:13)
    at async Object.uiAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/ddu/app.ts#1312.309749:326:9)
    at async dispatch (https://deno.land/x/messagepack_rpc@v2.0.0/dispatcher.ts:36:12)
    at async Session.#dispatch (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:244:22)
    at async Session.#handleRequestMessage (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:271:33)
stack traceback:
	[C]: in function 'ddu#ui#do_action'
	/home/ogaken/.config/nvim/lua/rc/ddu.lua:360: in function </home/ogaken/.config/nvim/lua/rc/ddu.lua:358>

function <lambda>1486[1]..<SNR>59_do_auto_action[9]..ddu#ui#sync_action[1]..ddu#ui_sync_action[4]..ddu#_request[15]..denops#request[1]..denops#server#request[4]..denops#_internal#server#chan#request[4]..denops#_internal#rpc#nvim#request の処理中にエラーが検出されました:
行    1:
Error invoking 'invoke' on channel 4:
TypeError: Cannot read properties of null (reading 'edit')
    at ensureAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-kinds/lsp_codeAction.ts:70:40)
    at eventLoopTick (ext:core/01_core.js:183:11)
    at async Kind.getPreviewer (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-kinds/lsp_codeAction.ts:118:20)
    at async PreviewUi.previewContents (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-ui-ff/preview.ts:96:23)
    at async Ddu.uiAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/ddu/ddu.ts:727:13)
    at async Object.uiAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/ddu/app.ts#1312.309749:326:9)
    at async dispatch (https://deno.land/x/messagepack_rpc@v2.0.0/dispatcher.ts:36:12)
    at async Session.#dispatch (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:244:22)
    at async Session.#handleRequestMessage (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:271:33)
function <lambda>1555[1]..<SNR>59_do_auto_action[9]..ddu#ui#sync_action[1]..ddu#ui_sync_action[4]..ddu#_request[15]..denops#request[1]..denops#server#request[4]..denops#_internal#server#chan#request[4]..denops#_internal#rpc#nvim#request の処理中にエラーが検出されました:
行    1:
Error invoking 'invoke' on channel 4:
TypeError: Cannot read properties of null (reading 'edit')
    at ensureAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-kinds/lsp_codeAction.ts:70:40)
    at eventLoopTick (ext:core/01_core.js:183:11)
    at async Kind.getPreviewer (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-kinds/lsp_codeAction.ts:118:20)
    at async PreviewUi.previewContents (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/@ddu-ui-ff/preview.ts:96:23)
    at async Ddu.uiAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/ddu/ddu.ts:727:13)
    at async Object.uiAction (file:///home/ogaken/.cache/nvim/dein/.cache/init.vim/.dein/denops/ddu/app.ts#1312.309749:326:9)
    at async dispatch (https://deno.land/x/messagepack_rpc@v2.0.0/dispatcher.ts:36:12)
    at async Session.#dispatch (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:244:22)
    at async Session.#handleRequestMessage (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:271:33)
```

Screen shot

![image](https://github.com/uga-rosa/ddu-source-lsp/assets/60453380/e9250187-b3ec-4167-89d4-95a3b3b159ad)
