### PR TITLE
fix(codeAction): Can't apply codeAction when used with ddu filters

### DIFF
--- a/denops/@ddu-kinds/lsp_codeAction.ts
+++ b/denops/@ddu-kinds/lsp_codeAction.ts
@@ -38,6 +38,7 @@ export type ActionData = {
   command?: LSP.Command;
   context: Omit<ItemContext, "method">;
   resolved?: boolean;
+  codeAction: LSP.Command | LSP.CodeAction;
 };
 
 async function ensureAction(
@@ -55,7 +56,7 @@ async function ensureAction(
         denops,
         action.context.client,
         "codeAction/resolve",
-        item.data,
+        action.codeAction,
         action.context.bufNr,
       ) as LSP.CodeAction | null;
       action.edit = resolvedCodeAction?.edit;

--- a/denops/@ddu-sources/lsp_codeAction.ts
+++ b/denops/@ddu-sources/lsp_codeAction.ts
@@ -83,8 +83,8 @@ function parseResult(
     action: {
       ...isCodeAction(codeAction) ? pick(codeAction, "edit", "command") : { command: codeAction },
       context,
+      codeAction,
     },
-    data: codeAction,
   }));
 }
 


### PR DESCRIPTION
## Problem

Some filters use `data` field to store their's internal values. This makes `pamras` for `codeAction/resolve` invalid.

## Solution

Add `codeAction` field to ActionData of codeAction kind and use it.