### PR TITLE
fix: Fix highlighting issue caused by multi-byte characters in converter_lsp_diagnostic(#32)

### DIFF
--- a/denops/@ddu-filters/converter_lsp_diagnostic.ts
+++ b/denops/@ddu-filters/converter_lsp_diagnostic.ts
@@ -76,6 +76,7 @@ export class Filter extends BaseFilter<Params> {
         denops,
         param.iconMap[severityName],
         iconLength,
+        false,
       );
       // To prioritize speed, decodePosition() is not used.
       // So, row may not be correct.


### PR DESCRIPTION
## purpose

Fix #32 

## solution

Changed the padding method due to unnatural spacing to the left of the icon.


Since I'm still learning, please feel free to point out any mistakes or errors in my pull request. Your feedback is greatly appreciated.