### PR TITLE
Check if the method is supported before request (nvim-lsp)

### DIFF
--- a/lua/ddu_nvim_lsp.lua
+++ b/lua/ddu_nvim_lsp.lua
@@ -30,6 +30,9 @@ function M.request(clientId, method, params, bufNr)
   if not client then
     return
   end
+  if not client.supports_method(method) then
+    return
+  end
   local response = client.request_sync(method, params, 5000, bufNr)
 
   if response and response.result then


### PR DESCRIPTION
Thanks for your job.
I discovered a bug when using multiple LSP servers with nvim-lsp and have implemented a fix to address it.

When using multiple LSP servers with nvim-lsp, I encountered an issue where requests to unsupported methods cause significant delays and fail to return a proper response. Specifically, if one of the servers does not support the requested method, the request waits for a timeout before returning, leading to undesirable behavior.

For instance, I experienced this issue while using denols alongside [testing-language-server](https://github.com/kbwo/testing-language-server), which does not support definitionProvider. When executing :call ddu#start(#{sources: [#{name: 'lsp_definition'}]}) to send a textDocument/definition request, the process waits for the 5000 ms timeout defined [here](https://github.com/kbwo/ddu-source-lsp/blob/main/lua/ddu_nvim_lsp.lua#L33), after which all LSP servers appear to return null.

This behavior seems to stem from the use of Promise.all for parallel processing, as noted here. Replacing [this `Promise.all`](https://github.com/kbwo/ddu-source-lsp/blob/b9df7182658ca7955cc20416d86efc935e685e7d/denops/%40ddu-sources/lsp_definition.ts#L40) with a for...of loop resolved the issue in my testing, ensuring correct execution. However, I understand that Promise.all is likely used to optimize performance, and switching to sequential execution might introduce performance issue.

To resolve the issue without sacrificing performance, I implemented a fix that checks if the requested method is supported before invoking nvimLspRequest using [`supports_method`](https://neovim.io/doc/user/lsp.html#_lua-module:-vim.lsp.client). This approach maintains parallel processing while ensuring unsupported methods are not unnecessarily queried.
