### PR TITLE
Option to show line content in references added

### DIFF
--- a/denops/ddu_source_lsp/util.ts
+++ b/denops/ddu_source_lsp/util.ts
@@ -30,6 +30,8 @@ export function locationToItem(
   location: LSP.Location | LSP.LocationLink,
   cwd: string,
   context: ItemContext,
+  text: string | null = null,
+  loc_padding: int | null = null
 ) {
   const uri = "uri" in location ? location.uri : location.targetUri;
   const range = "range" in location ? location.range : location.targetSelectionRange;
@@ -37,9 +39,12 @@ export function locationToItem(
   const relativePath = relative(cwd, path);
   const { line, character } = range.start;
   const [lineNr, col] = [line + 1, character + 1];
+  const display_loc = `${relativePath}:${lineNr}:${col}`
+  const is_loc_padding_valid = Number.isInteger(loc_padding) && loc_padding > 0
+  const display = text ? (is_loc_padding_valid ? display_loc.padEnd(loc_padding) + ` ${text}` : display_loc + `  ${text}`) : display_loc;
   return {
     word: relativePath,
-    display: `${relativePath}:${lineNr}:${col}`,
+    display,
     action: { path, range, context },
     data: location,
   };

--- a/doc/ddu-source-lsp.txt
+++ b/doc/ddu-source-lsp.txt
@@ -234,6 +234,23 @@ includeDeclaration (boolean)
 
 	Default: true
 
+					*ddu-source-lsp-params-showLine*
+showLine (boolean)
+	Available in |ddu-source-lsp_references|.
+	Whether to show the line content of found references.
+	Note: Enabling this option may slow down the source because it needs
+	to read files to get the line content.
+
+	Default: false
+
+				*ddu-source-lsp-params-locationPaddingWidth*
+locationPaddingWidth (number)
+	Available in |ddu-source-lsp_references|.
+	If showLine is enabled, add spaces padding to the location text so
+	that resulting location part has the width of this number.
+
+	Default: 30
+
 					*ddu-source-lsp-params-query*
 query	(string)
 	Available in |ddu-source-lsp_workspaceSymbol|.


### PR DESCRIPTION
Tried to reproduce built-in lsp features, by which we see contents at the reference locations in quickfix.
As noted in the doc, it might be slow since denops would open many files to read the content.
In default this option is disabled.